### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -526,7 +526,7 @@ data to it. This is what the `tcp-request content track-sc0 src` parameter does.
 
 Now that we have tracking in place, we can write ACLs that run tests against the
 content of the table. The examples below evaluate several of these counters
-against arbitary limits. Tune these to your needs.
+against arbitrary limits. Tune these to your needs.
 
 .. code::
 


### PR DESCRIPTION
@jvehent, I've corrected a typographical error in the documentation of the [haproxy-aws](https://github.com/jvehent/haproxy-aws) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
